### PR TITLE
Fix vercel deployment and backend communication

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "rewrites": [
     {
       "source": "/((?!api|_next/static|_next/image|favicon.ico).*)",


### PR DESCRIPTION
Add `version: 2` to `frontend/vercel.json` to resolve Vercel deployment error `Function Runtimes must have a valid version`.

---

[Open in Web](https://cursor.com/agents?id=bc-789ab795-d642-4fa3-9f57-5e9fb13c7a82) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-789ab795-d642-4fa3-9f57-5e9fb13c7a82) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)